### PR TITLE
Features/multiple songs ignore melismata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "cantara-songlib"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cbindgen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Jan Martin Reckel jm.reckel@t-online.de"]
 description = "Functionalities to import, manage and export songs in various formats"
 keywords = ["music", "sheets", "presentation"]
 license = "AGPL-3.0"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 repository = "https://github.com/CantaraProject/cantara-songlib"
 

--- a/src/exporter/abc.rs
+++ b/src/exporter/abc.rs
@@ -830,6 +830,40 @@ struct Syllable {
     text: String,
     /// The syllable continues the previous word and is joined with a hyphen.
     joined: bool,
+    /// The syllable sits in a region where melismata are ignored, so it takes a
+    /// note of its own even where the music slurs or ties.
+    ignore_melismata: bool,
+}
+
+impl Syllable {
+    /// A plain syllable outside any `ignoreMelismata` region.
+    fn plain(text: impl Into<String>, joined: bool) -> Self {
+        Syllable {
+            text: text.into(),
+            joined,
+            ignore_melismata: false,
+        }
+    }
+}
+
+/// Whether melismata are currently ignored while a lyrics block is parsed.
+///
+/// The state outlives a single line: LilyPond's `\set ignoreMelismata = ##t`
+/// holds until the matching `\unset`, and the bracket form may wrap several
+/// lines just as well.
+#[derive(Clone, Copy, Default, Debug)]
+struct IgnoreMelismata {
+    /// Turned on by `\set ignoreMelismata = ##t`.
+    set: bool,
+    /// Open `[` brackets; they nest so that a stray one cannot swallow the
+    /// rest of the song.
+    brackets: usize,
+}
+
+impl IgnoreMelismata {
+    fn active(&self) -> bool {
+        self.set || self.brackets > 0
+    }
 }
 
 /// Escape the characters ABC treats as control characters inside a `w:` line.
@@ -849,21 +883,39 @@ fn escape_lyric_text(text: &str) -> String {
 
 /// Split a LilyPond lyrics line into syllables.
 ///
-/// `--` (as its own token or inside a word) marks a syllable break, `_` is a
-/// melisma extender and is passed through, and inline commands such as
-/// `\set ignoreMelismata = ##t` are removed together with their arguments.
-fn lyrics_line_to_syllables(line: &str) -> Vec<Syllable> {
+/// `--` (as its own token or inside a word) marks a syllable break and `_` is a
+/// melisma extender that is passed through.
+///
+/// Two forms switch melismata off, so that the text is spread over every note
+/// even where the music slurs or ties — useful when one stanza needs a syllable
+/// on each of the notes another stanza sings as a melisma:
+///
+/// * LilyPond's `\set ignoreMelismata = ##t` … `\unset ignoreMelismata`
+/// * a `[…]` bracket around the affected words
+///
+/// Both may span several lines of the same lyrics block, which is why the state
+/// is threaded in and out rather than reset per line. Any other inline command
+/// is dropped together with its arguments.
+fn lyrics_line_to_syllables_with(line: &str, state: &mut IgnoreMelismata) -> Vec<Syllable> {
     let mut syllables: Vec<Syllable> = Vec::new();
     let mut join_next = false;
     let mut words = line.split_whitespace().peekable();
 
     while let Some(word) = words.next() {
         if word.starts_with('\\') {
-            // Drop the command, its target and an optional `= value`.
-            words.next();
+            // `\set ignoreMelismata = ##t` and `\unset ignoreMelismata` carry
+            // meaning; every other command is dropped with its arguments.
+            let target = words.next();
+            let is_ignore_melismata = target == Some("ignoreMelismata");
             if words.peek() == Some(&"=") {
                 words.next();
-                words.next();
+                let value = words.next();
+                if is_ignore_melismata {
+                    // `##f` turns the setting back off just like `\unset`.
+                    state.set = value != Some("##f");
+                }
+            } else if is_ignore_melismata && word == "\\unset" {
+                state.set = false;
             }
             continue;
         }
@@ -873,37 +925,55 @@ fn lyrics_line_to_syllables(line: &str) -> Vec<Syllable> {
             continue;
         }
 
+        // Brackets may stand alone or hug the words they enclose.
+        let opened = word.chars().take_while(|c| *c == '[').count();
+        state.brackets += opened;
+        let word = &word[opened..];
+        let closing = word.chars().rev().take_while(|c| *c == ']').count();
+        let word = &word[..word.len() - closing];
+
         if word == "_" {
             syllables.push(Syllable {
                 text: "_".to_string(),
                 joined: false,
+                ignore_melismata: state.active(),
             });
-            continue;
-        }
-
-        // A word may carry the syllable separator without spaces ("hei--lig").
-        for (index, chunk) in word.split("--").enumerate() {
-            if chunk.is_empty() {
-                continue;
+        } else {
+            // A word may carry the syllable separator without spaces
+            // ("hei--lig").
+            for (index, chunk) in word.split("--").enumerate() {
+                if chunk.is_empty() {
+                    continue;
+                }
+                syllables.push(Syllable {
+                    text: escape_lyric_text(chunk),
+                    joined: join_next || index > 0,
+                    ignore_melismata: state.active(),
+                });
+                join_next = false;
             }
-            syllables.push(Syllable {
-                text: escape_lyric_text(chunk),
-                joined: join_next || index > 0,
-            });
             join_next = false;
         }
-        join_next = false;
+
+        state.brackets = state.brackets.saturating_sub(closing);
     }
 
     syllables
 }
 
+/// Split a lyrics line on its own, starting outside any ignore region.
+#[cfg(test)]
+fn lyrics_line_to_syllables(line: &str) -> Vec<Syllable> {
+    lyrics_line_to_syllables_with(line, &mut IgnoreMelismata::default())
+}
+
 /// Split a whole lyrics block into one syllable list per line, dropping lines
 /// which contain no singable text.
 fn lyrics_to_lines(content: &str) -> Vec<Vec<Syllable>> {
+    let mut state = IgnoreMelismata::default();
     content
         .lines()
-        .map(lyrics_line_to_syllables)
+        .map(|line| lyrics_line_to_syllables_with(line, &mut state))
         .filter(|line| !line.is_empty())
         .collect()
 }
@@ -916,6 +986,61 @@ fn lyrics_to_lines(content: &str) -> Vec<Vec<Syllable>> {
 /// `(F G)` under "Denn wer" would put "wer" on the second note of the slur
 /// instead of holding "Denn" across both.
 ///
+/// Whether a note takes the next syllable instead of holding the previous one.
+///
+/// A slur or a tie makes a note a melisma — unless the syllable waiting to be
+/// sung sits in an `ignoreMelismata` region, which spreads the text over every
+/// note regardless of what the music does.
+fn note_takes_syllable(is_slot: bool, pending: Option<&Syllable>) -> bool {
+    is_slot || pending.is_some_and(|syllable| syllable.ignore_melismata)
+}
+
+/// How many syllable slots a stretch of music offers to `syllables`.
+///
+/// Notes past the end of the text are counted by the music alone, so a line
+/// with little text still reports the full capacity a caller needs to pad it
+/// out to.
+fn slot_capacity(events: &[MusicEvent], flags: &[bool], syllables: &[Syllable]) -> usize {
+    let mut cursor = 0usize;
+    let mut slots = 0usize;
+
+    for (index, event) in events.iter().enumerate() {
+        if !event.is_note() {
+            continue;
+        }
+        if note_takes_syllable(flags[index], syllables.get(cursor)) {
+            slots += 1;
+            cursor = (cursor + 1).min(syllables.len());
+        }
+    }
+
+    slots
+}
+
+/// How many of `syllables` fit onto the notes of `events`.
+///
+/// Unlike [`slot_capacity`] this stops at the end of the text. It is the
+/// capacity of one music line for one particular verse — not a property of the
+/// music alone, because an `ignoreMelismata` region lets a verse put text on
+/// notes another verse sings as a melisma.
+fn syllables_fitting(events: &[MusicEvent], flags: &[bool], syllables: &[Syllable]) -> usize {
+    let mut cursor = 0usize;
+
+    for (index, event) in events.iter().enumerate() {
+        if !event.is_note() {
+            continue;
+        }
+        if cursor >= syllables.len() {
+            break;
+        }
+        if note_takes_syllable(flags[index], syllables.get(cursor)) {
+            cursor += 1;
+        }
+    }
+
+    cursor
+}
+
 /// `flags` are the slot flags of `events` and must be sliced in step with it.
 ///
 /// Returns the rendered body together with the number of syllables it used, so
@@ -939,7 +1064,7 @@ fn render_syllables_over_notes(
             continue;
         }
 
-        if flags[index] {
+        if note_takes_syllable(flags[index], syllables.get(cursor)) {
             // Once the text has run out the remaining notes stay bare rather
             // than getting melisma markers for a syllable that is not there.
             let Some(syllable) = syllables.get(cursor) else {
@@ -1036,17 +1161,20 @@ fn segment_events(events: &[MusicEvent], reference: &[Vec<Syllable>]) -> Vec<(us
         let mut seen = 0usize;
 
         if is_last_line {
-            // Everything that is left belongs to the final line.
+            // Everything that is left belongs to the final line. Its slot count
+            // is the music's capacity, not the length of this verse's text —
+            // a shorter line is padded up to it.
             index = events.len();
-            seen = flags[start..].iter().filter(|f| **f).count();
+            seen = slot_capacity(&events[start..], &flags[start..], line);
         } else {
             while index < events.len() && seen < wanted {
-                if flags[index] {
+                if events[index].is_note() && note_takes_syllable(flags[index], line.get(seen)) {
                     seen += 1;
                 }
                 index += 1;
             }
-            // Pull trailing bar lines and rests into this line.
+            // Pull trailing bar lines and rests into this line. A melisma note
+            // belongs to the syllable before it, so it stays here too.
             while index < events.len() && !flags[index] {
                 index += 1;
             }
@@ -1119,8 +1247,14 @@ fn render_section(
 
             let is_last_segment = segment_index + 1 == segments.len();
             // Never write more syllables than the line has notes — ABC would
-            // drop the surplus and the text would slide out of alignment.
-            let take = (*slots).min(syllables.len() - cursor);
+            // drop the surplus and the text would slide out of alignment. The
+            // capacity is measured per verse: an `ignoreMelismata` region lets
+            // this one put text on notes another verse holds a syllable over.
+            let take = syllables_fitting(
+                &section.events[*start..*end],
+                &flags[*start..*end],
+                &syllables[cursor..],
+            );
 
             let mut chunk: Vec<Syllable> = syllables[cursor..cursor + take].to_vec();
             cursors[stream_index] = cursor + take;
@@ -1129,10 +1263,7 @@ fn render_section(
             // so the following lines stay aligned.
             if !is_last_segment && chunk.len() < *slots {
                 for _ in chunk.len()..*slots {
-                    chunk.push(Syllable {
-                        text: "*".to_string(),
-                        joined: false,
-                    });
+                    chunk.push(Syllable::plain("*", false));
                 }
             }
 
@@ -1663,10 +1794,7 @@ impl PartPhrases {
                 let mut syllables: Vec<Syllable> = line.clone();
                 // Pad so that the remaining words stay under the right notes.
                 while syllables.len() < slots {
-                    syllables.push(Syllable {
-                        text: "*".to_string(),
-                        joined: false,
-                    });
+                    syllables.push(Syllable::plain("*", false));
                 }
                 if !syllables.is_empty() {
                     let (mut line, used) = render_syllables_over_notes(
@@ -2167,6 +2295,148 @@ mod tests {
     #[test]
     fn test_rests_do_not_take_a_syllable_or_a_melisma_marker() {
         assert_eq!(w_line("c4 r4 d8( e )", "one two"), "one two _");
+    }
+
+    // --- Ignoring melismata ---------------------------------------------
+
+    /// Inside an `ignoreMelismata` region the text is spread over every note,
+    /// slur or no slur, so no `_` is emitted.
+    #[test]
+    fn test_set_ignore_melismata_spreads_the_text_over_every_note() {
+        assert_eq!(
+            w_line(
+                "c4( d ) e f",
+                "\\set ignoreMelismata = ##t one two three four"
+            ),
+            "one two three four"
+        );
+    }
+
+    /// The same music without the setting holds the first syllable.
+    #[test]
+    fn test_without_the_setting_the_slur_is_a_melisma_again() {
+        assert_eq!(w_line("c4( d ) e f", "one two three"), "one _ two three");
+    }
+
+    #[test]
+    fn test_unset_ignore_melismata_switches_back_mid_line() {
+        // Two slurs: the first falls inside the region and is spread over, the
+        // second is behind the `\unset` and becomes a melisma again.
+        assert_eq!(
+            w_line(
+                "c4( d ) e f( g ) a",
+                "\\set ignoreMelismata = ##t one two \\unset ignoreMelismata three four five"
+            ),
+            "one two three four _ five"
+        );
+    }
+
+    /// `##f` is the other way LilyPond turns the setting off.
+    #[test]
+    fn test_setting_ignore_melismata_to_false_turns_it_off() {
+        assert_eq!(
+            w_line(
+                "c4( d ) e",
+                "\\set ignoreMelismata = ##f one two"
+            ),
+            "one _ two"
+        );
+    }
+
+    /// The bracket form is the shorthand for the same thing.
+    #[test]
+    fn test_brackets_ignore_melismata() {
+        assert_eq!(w_line("c4( d ) e f", "[one two] three four"), "one two three four");
+    }
+
+    /// Brackets may hug their words rather than standing alone.
+    #[test]
+    fn test_brackets_may_be_attached_to_the_words() {
+        assert_eq!(w_line("c4( d ) e", "[Da -- rum] hier"), "Da-rum hier");
+    }
+
+    /// Outside the brackets the melisma is back.
+    #[test]
+    fn test_brackets_only_reach_to_the_closing_one() {
+        assert_eq!(
+            w_line("c4 d4( e ) f", "[one] two three"),
+            "one two _ three"
+        );
+    }
+
+    /// A `[` that is never closed must not swallow the rest of the song, and a
+    /// stray `]` must not underflow the nesting count.
+    #[test]
+    fn test_unbalanced_brackets_are_survivable() {
+        assert_eq!(w_line("c4( d ) e", "[one two"), "one two");
+        assert_eq!(w_line("c4( d ) e", "one] two"), "one _ two");
+    }
+
+    /// The setting holds across the lines of one lyrics block, the way
+    /// LilyPond's does — it ends at `\unset`, not at the line break.
+    #[test]
+    fn test_ignore_melismata_spans_lines_of_a_block() {
+        let lines = lyrics_to_lines("\\set ignoreMelismata = ##t one\ntwo\n\\unset ignoreMelismata three");
+        assert!(lines[0][0].ignore_melismata, "{:?}", lines);
+        assert!(lines[1][0].ignore_melismata, "the setting ended at the line break");
+        assert!(!lines[2][0].ignore_melismata, "{:?}", lines);
+    }
+
+    #[test]
+    fn test_brackets_span_lines_of_a_block() {
+        let lines = lyrics_to_lines("[one\ntwo]\nthree");
+        assert!(lines[0][0].ignore_melismata, "{:?}", lines);
+        assert!(lines[1][0].ignore_melismata, "{:?}", lines);
+        assert!(!lines[2][0].ignore_melismata, "{:?}", lines);
+    }
+
+    /// Commands other than `ignoreMelismata` are still dropped whole.
+    #[test]
+    fn test_other_commands_are_still_dropped_with_their_arguments() {
+        let syllables = lyrics_line_to_syllables("\\set fontSize = #2 one two");
+        assert_eq!(render_syllables(&syllables), "one two");
+    }
+
+    /// The case this exists for: one stanza needs a syllable on a note that
+    /// another stanza sings as a melisma. Both have to stay aligned, and the
+    /// following music line must start in the same place for both.
+    #[test]
+    fn test_stanzas_with_and_without_melismata_stay_aligned() {
+        let yml = r#"
+version: 0.1
+title: Mixed Melismata
+score:
+  key: c major
+  time: 4/4
+parts:
+  - type: stanza
+    contents:
+    - type: voice
+      number: 1
+      content: |
+        c4( d ) e f | g4 a b c
+    - type: lyrics
+      number: 1
+      content: |
+        one two three
+        four five six seven
+    - type: lyrics
+      number: 2
+      content: |
+        [ei ne] zwei drei
+        vier fünf sechs sieben
+"#;
+        let song = song_yml::import_from_yml_string(yml).unwrap();
+        let abc = abc_from_song(&song, &AbcSettings::default()).unwrap();
+
+        // The slur holds "one" in verse 1 but carries "ne" in verse 2.
+        assert!(abc.contains("w:1.~one _ two three"), "{}", abc);
+        assert!(abc.contains("w:2.~ei ne zwei drei"), "{}", abc);
+        // Both verses resume together on the second music line.
+        assert!(abc.contains("w:four five six seven"), "{}", abc);
+        assert!(abc.contains("w:vier fünf sechs sieben"), "{}", abc);
+        // Nothing was pushed past the end of the melody.
+        assert!(!abc.contains("% unaligned"), "{}", abc);
     }
 
     // --- Bar lines and rests --------------------------------------------

--- a/src/exporter/abc.rs
+++ b/src/exporter/abc.rs
@@ -908,6 +908,82 @@ fn lyrics_to_lines(content: &str) -> Vec<Vec<Syllable>> {
         .collect()
 }
 
+/// Render the body of a `w:` line against the notes it is sung on.
+///
+/// ABC binds the tokens of a `w:` line to notes one by one, so a note that
+/// continues a tie or sits inside a slur needs an explicit `_` melisma marker.
+/// Without it every syllable behind the melisma slides one note to the left —
+/// `(F G)` under "Denn wer" would put "wer" on the second note of the slur
+/// instead of holding "Denn" across both.
+///
+/// `flags` are the slot flags of `events` and must be sliced in step with it.
+///
+/// Returns the rendered body together with the number of syllables it used, so
+/// that a caller which must not lose surplus text can append the remainder.
+fn render_syllables_over_notes(
+    events: &[MusicEvent],
+    flags: &[bool],
+    syllables: &[Syllable],
+) -> (String, usize) {
+    let mut result = String::new();
+    let mut cursor = 0usize;
+    let mut tokens = 0usize;
+    // Whether the hyphen joining the next syllable to the current word has
+    // already been written. A melisma inside a word has to be spelled
+    // `al- _ rea-dy`: the hyphen belongs to the syllable the melisma extends,
+    // not to the one that resumes after it.
+    let mut hyphen_written = false;
+
+    for (index, event) in events.iter().enumerate() {
+        if !event.is_note() {
+            continue;
+        }
+
+        if flags[index] {
+            // Once the text has run out the remaining notes stay bare rather
+            // than getting melisma markers for a syllable that is not there.
+            let Some(syllable) = syllables.get(cursor) else {
+                break;
+            };
+            if tokens > 0 {
+                result.push(if syllable.joined && !hyphen_written {
+                    '-'
+                } else {
+                    ' '
+                });
+            }
+            result.push_str(&syllable.text);
+            hyphen_written = false;
+            cursor += 1;
+        } else {
+            // The note belongs to the syllable written last. If the word
+            // continues after the melisma, close it with its hyphen first.
+            if !hyphen_written && syllables.get(cursor).is_some_and(|s| s.joined) {
+                result.push('-');
+                hyphen_written = true;
+            }
+            if tokens > 0 {
+                result.push(' ');
+            }
+            result.push('_');
+        }
+
+        tokens += 1;
+    }
+
+    (result, cursor)
+}
+
+/// Append syllables that found no note behind an already rendered `w:` body.
+fn append_surplus_syllables(body: &mut String, syllables: &[Syllable]) {
+    for syllable in syllables {
+        if !body.is_empty() {
+            body.push(if syllable.joined { '-' } else { ' ' });
+        }
+        body.push_str(&syllable.text);
+    }
+}
+
 /// Render a list of syllables as the body of an ABC `w:` line.
 fn render_syllables(syllables: &[Syllable]) -> String {
     let mut result = String::new();
@@ -1004,6 +1080,9 @@ fn render_section(
         .unwrap_or(&[]);
 
     let segments = segment_events(&section.events, reference);
+    // Computed over the whole section so that slur and tie state is not lost
+    // at a segment boundary; sliced per segment below.
+    let flags = slot_flags(&section.events);
 
     // Flatten every verse into a single syllable stream so that verses with a
     // different line layout still line up with the music.
@@ -1068,7 +1147,14 @@ fn render_section(
                 String::new()
             };
 
-            output.push_str(&format!("w:{}{}\n", prefix, render_syllables(&chunk)));
+            // The chunk is already capped at the line's slot count, so nothing
+            // is left over here.
+            let (body, _) = render_syllables_over_notes(
+                &section.events[*start..*end],
+                &flags[*start..*end],
+                &chunk,
+            );
+            output.push_str(&format!("w:{}{}\n", prefix, body));
         }
     }
 
@@ -1138,6 +1224,41 @@ fn build_header(song: &Song, settings: &AbcSettings) -> String {
     header.push_str("V:1\n");
 
     header
+}
+
+/// Build a text-only tune for a song that carries no notation.
+///
+/// There is no staff to hang syllables on, so the lyrics go into `W:` fields —
+/// the ABC standard's "words printed after the tune" — instead of the `w:`
+/// lines that align text to notes. `K:none` closes the header without claiming
+/// a key the song does not have.
+fn abc_lyrics_only(song: &Song) -> String {
+    let mut output = String::from("X:1\n");
+    output.push_str(&format!("T:{}\n", song.title));
+    if let Some(author) = song.tag("author") {
+        output.push_str(&format!("C:{}\n", author));
+    }
+    output.push_str("K:none\n");
+
+    for (index, block) in crate::exporter::readable_lyrics_blocks(song)
+        .iter()
+        .enumerate()
+    {
+        if index > 0 {
+            // An empty W: field is the standard's blank line between verses.
+            output.push_str("W:\n");
+        }
+        for (line_number, line) in block.lines.iter().enumerate() {
+            let prefix = if line_number == 0 {
+                format!("{} ", block.label)
+            } else {
+                String::new()
+            };
+            output.push_str(&format!("W:{}{}\n", prefix, line));
+        }
+    }
+
+    output
 }
 
 /// Collect the stanza and refrain sections of a song in singing order.
@@ -1501,7 +1622,7 @@ impl PartPhrases {
     ///
     /// // One music line and one lyrics line per phrase.
     /// assert_eq!(abc.matches("w:").count(), 2);
-    /// assert!(abc.contains("w:A-ma-zing grace, How sweet the sound"));
+    /// assert!(abc.contains("w:A-ma-zing _ grace, How sweet the sound"));
     /// ```
     pub fn excerpt_with_lyrics(
         &self,
@@ -1526,6 +1647,7 @@ impl PartPhrases {
         // over a line break as long as the bar has not ended.
         let mut bar = BarAccidentals::default();
         let mut body = String::new();
+        let flags = slot_flags(&self.events);
 
         for index in lines.clone() {
             let (start, end, slots) = self.segments[index];
@@ -1547,7 +1669,17 @@ impl PartPhrases {
                     });
                 }
                 if !syllables.is_empty() {
-                    body.push_str(&format!("w:{}\n", render_syllables(&syllables)));
+                    let (mut line, used) = render_syllables_over_notes(
+                        &self.events[start..end],
+                        &flags[start..end],
+                        &syllables,
+                    );
+                    // A phrase with more syllables than notes is written out in
+                    // full — every phrase has its own `w:` line, so the surplus
+                    // cannot displace anything, and cutting it would show a
+                    // mangled word.
+                    append_surplus_syllables(&mut line, &syllables[used..]);
+                    body.push_str(&format!("w:{}\n", line));
                 }
             }
         }
@@ -1598,8 +1730,18 @@ fn build_excerpt_header(song: &Song, settings: &AbcSettings) -> String {
 /// per verse aligned to the notes. If the refrain has its own melody it is
 /// emitted as a separate, labelled section.
 ///
-/// Returns an error if the song contains no voice content.
+/// A song without any notation is exported as a text-only tune whose lyrics sit
+/// in `W:` fields — see [`abc_lyrics_only`].
+///
+/// Returns an error only if the song has neither notation nor lyrics.
 pub fn abc_from_song(song: &Song, settings: &AbcSettings) -> Result<String, String> {
+    if !song.has_voice_content() {
+        if !song.has_lyrics_content() {
+            return Err("Song has neither voice nor lyrics content for ABC export".to_string());
+        }
+        return Ok(abc_lyrics_only(song));
+    }
+
     let mut output = build_header(song, settings);
 
     let unit = parse_unit_note_length(&settings.unit_note_length);
@@ -1654,13 +1796,17 @@ pub fn abc_from_song_separated(song: &Song, settings: &AbcSettings) -> Result<St
         output.push_str(&line);
         output.push('\n');
 
+        let flags = slot_flags(&section.events);
         for (label, lines) in &section.lyrics {
             let syllables: Vec<Syllable> = lines.iter().flatten().cloned().collect();
             if syllables.is_empty() {
                 continue;
             }
             let prefix = label.clone().map(|l| format!("{}~", l)).unwrap_or_default();
-            output.push_str(&format!("w:{}{}\n", prefix, render_syllables(&syllables)));
+            let (mut body, used) =
+                render_syllables_over_notes(&section.events, &flags, &syllables);
+            append_surplus_syllables(&mut body, &syllables[used..]);
+            output.push_str(&format!("w:{}{}\n", prefix, body));
         }
     }
 
@@ -1968,6 +2114,61 @@ mod tests {
         assert_eq!(flags.iter().filter(|f| **f).count(), 3);
     }
 
+    /// Render `syllables` over `voice` the way a `w:` line is built.
+    fn w_line(voice: &str, syllables: &str) -> String {
+        let events = parse_voice(voice);
+        let flags = slot_flags(&events);
+        render_syllables_over_notes(&events, &flags, &lyrics_line_to_syllables(syllables)).0
+    }
+
+    /// ABC binds one `w:` token per note, so every note a slur or a tie
+    /// swallows needs a `_`. Without it the text slides off the melody from the
+    /// melisma onwards.
+    #[test]
+    fn test_melisma_holds_its_syllable_over_every_slurred_note() {
+        // The refrain of "Sei nicht stolz": "Denn" spans the slurred fis–g.
+        assert_eq!(
+            w_line("fis8( g ) | a8 a a a d,4.", "Denn wer sich rüh -- men will,"),
+            "Denn _ wer sich rüh-men will,"
+        );
+    }
+
+    #[test]
+    fn test_melisma_marks_tied_notes_too() {
+        assert_eq!(w_line("c4 d4~ d4 e4", "one two three"), "one two _ three");
+    }
+
+    #[test]
+    fn test_several_melismas_in_one_line() {
+        assert_eq!(
+            w_line("d8( e ) | f f g f8( e )", "denn er ist uns nicht"),
+            "denn _ er ist uns nicht _"
+        );
+    }
+
+    /// A melisma inside a word keeps the hyphen on the syllable it extends —
+    /// `al- _ rea-dy`, never `al _-rea-dy`.
+    #[test]
+    fn test_melisma_inside_a_word_keeps_the_hyphen_with_its_syllable() {
+        // Slur on the first syllable of the word …
+        assert_eq!(w_line("c4( d ) e4 f4", "al -- rea -- dy"), "al- _ rea-dy");
+        // … and on the second: the hyphen always closes the syllable the
+        // melisma extends, so the word never breaks across the marker.
+        assert_eq!(w_line("c4 d4( e ) f4", "al -- rea -- dy"), "al-rea- _ dy");
+    }
+
+    /// A note without text left stays bare instead of collecting stray markers.
+    #[test]
+    fn test_melisma_marker_stops_when_the_text_runs_out() {
+        assert_eq!(w_line("c4 d4 e4 f4", "one two"), "one two");
+    }
+
+    /// Rests carry no lyrics token at all.
+    #[test]
+    fn test_rests_do_not_take_a_syllable_or_a_melisma_marker() {
+        assert_eq!(w_line("c4 r4 d8( e )", "one two"), "one two _");
+    }
+
     // --- Bar lines and rests --------------------------------------------
 
     #[test]
@@ -2034,7 +2235,8 @@ mod tests {
 
         // Three verses × four lyric lines each.
         assert_eq!(abc.matches("w:").count(), 12);
-        assert!(abc.contains("w:1.~A-ma-zing grace,"));
+        // "zing" is held across the slurred `a8( f)`, so a melisma marker follows.
+        assert!(abc.contains("w:1.~A-ma-zing _ grace,"));
         assert!(abc.contains("w:2.~"));
         assert!(abc.contains("w:3.~"));
     }
@@ -2100,7 +2302,7 @@ mod tests {
 
         assert!(abc.contains("\"^Refrain\""), "refrain section missing:\n{}", abc);
         assert!(
-            abc.contains("Denn wer sich rüh-men will,"),
+            abc.contains("Denn _ wer sich rüh-men will,"),
             "refrain lyrics missing:\n{}",
             abc
         );
@@ -2188,23 +2390,54 @@ parts:
 
     // --- Errors and misc ------------------------------------------------
 
-    #[test]
-    fn test_abc_export_no_voice_error() {
-        let mut song = Song::new("Test No Voice");
+    /// Build a song whose only content is one verse of lyrics.
+    fn lyrics_only_song(title: &str, lyrics: &str) -> Song {
+        let mut song = Song::new(title);
         let id = song.add_part_of_type(SongPartType::Verse, Some(1));
-        {
-            let part = song.part_mut(&id).unwrap();
-            part.add_content(SongPartContent {
-                content_type: SongPartContentType::Lyrics {
-                    language: LyricLanguage::Default,
-                },
-                content: "Test lyrics".to_string(),
-            });
-        }
+        let part = song.part_mut(&id).unwrap();
+        part.add_content(SongPartContent {
+            content_type: SongPartContentType::Lyrics {
+                language: LyricLanguage::Default,
+            },
+            content: lyrics.to_string(),
+        });
+        song
+    }
+
+    /// Without notation there is no staff to align syllables to, so the text
+    /// goes into `W:` fields instead of `w:` lines.
+    #[test]
+    fn test_song_without_voice_exports_its_lyrics_as_words() {
+        let song = lyrics_only_song("Test No Voice", "Test lyrics\nSecond line");
+        let abc = abc_from_song(&song, &AbcSettings::default()).unwrap();
+
+        assert!(abc.contains("T:Test No Voice"), "{}", abc);
+        assert!(abc.contains("W:1. Test lyrics"), "{}", abc);
+        assert!(abc.contains("W:Second line"), "{}", abc);
+        // No staff means no note-aligned lyrics line and no voice.
+        assert!(!abc.contains("\nw:"), "{}", abc);
+        assert!(!abc.contains("V:1"), "{}", abc);
+    }
+
+    /// The syllable markup is for singing, not for reading.
+    #[test]
+    fn test_lyrics_only_export_strips_the_syllable_markup() {
+        let song = lyrics_only_song("Markup", "A -- ma -- zing grace _");
+        let abc = abc_from_song(&song, &AbcSettings::default()).unwrap();
+
+        assert!(abc.contains("W:1. Amazing grace"), "{}", abc);
+    }
+
+    /// A song with nothing in it at all is still an error — the caller decides
+    /// whether that deserves a warning or a failure.
+    #[test]
+    fn test_song_without_voice_and_lyrics_is_an_error() {
+        let mut song = Song::new("Empty");
+        song.add_part_of_type(SongPartType::Verse, Some(1));
 
         let result = abc_from_song(&song, &AbcSettings::default());
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("no voice content"));
+        assert!(result.unwrap_err().contains("neither voice nor lyrics"));
     }
 
     #[test]

--- a/src/exporter/lilypond.rs
+++ b/src/exporter/lilypond.rs
@@ -267,6 +267,65 @@ fn find_own_voice(part: &SongPart) -> Option<&SongPartContent> {
 }
 
 /// Find the first lyrics content in a part.
+/// Expand the `[…]` shorthand into LilyPond's own `ignoreMelismata` commands.
+///
+/// The bracket form is a Cantara convenience for "spread the text over every
+/// note here, slurs and all". LilyPond does not know it and would print the
+/// brackets as literal syllables, so they are translated on the way out.
+///
+/// Text without a bracket is handed back untouched — reflowing it would change
+/// the output of every song that never uses the feature.
+fn expand_ignore_melismata_brackets(lyrics: &str) -> String {
+    if !lyrics.contains('[') && !lyrics.contains(']') {
+        return lyrics.to_string();
+    }
+
+    let mut depth = 0usize;
+    let mut lines: Vec<String> = Vec::new();
+
+    for line in lyrics.lines() {
+        let mut words: Vec<String> = Vec::new();
+
+        for word in line.split_whitespace() {
+            let opened = word.chars().take_while(|c| *c == '[').count();
+            let word = &word[opened..];
+            let closing = word.chars().rev().take_while(|c| *c == ']').count();
+            let word = &word[..word.len() - closing];
+
+            if opened > 0 && depth == 0 {
+                words.push("\\set ignoreMelismata = ##t".to_string());
+            }
+            depth += opened;
+
+            if !word.is_empty() {
+                words.push(word.to_string());
+            }
+
+            let was_open = depth > 0;
+            depth = depth.saturating_sub(closing);
+            if closing > 0 && was_open && depth == 0 {
+                words.push("\\unset ignoreMelismata".to_string());
+            }
+        }
+
+        lines.push(words.join(" "));
+    }
+
+    let mut result = lines.join("\n");
+    // `lines()` drops a trailing newline; the callers indent whole blocks and
+    // expect the shape they were given.
+    if lyrics.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
+/// Prepare a lyrics block for the LilyPond output: expand the bracket
+/// shorthand, then indent it like every other block.
+fn lyrics_block(text: &str) -> String {
+    indent_lines(&expand_ignore_melismata_brackets(text), "  ")
+}
+
 fn find_lyrics(part: &SongPart) -> Option<&SongPartContent> {
     part.contents.iter().find(|c| c.content_type.is_lyrics())
 }
@@ -715,7 +774,7 @@ pub fn lilypond_from_song(song: &Song, settings: &LilypondSettings) -> Result<St
                 lyric_defs.push(LyricsDefinition {
                     var_name,
                     stanza: Some(format!("{}.", verse_number)),
-                    content: indent_lines(&content.content, "  "),
+                    content: lyrics_block(&content.content),
                 });
                 verse_number += 1;
             }
@@ -733,7 +792,7 @@ pub fn lilypond_from_song(song: &Song, settings: &LilypondSettings) -> Result<St
             var_name: "chorus".to_string(),
             // No `\set stanza` — the refrain carries no verse number.
             stanza: None,
-            content: indent_lines(chorus_text.trim(), "  "),
+            content: lyrics_block(chorus_text.trim()),
         });
 
         if verse_refs.is_empty() {
@@ -797,7 +856,7 @@ pub fn lilypond_from_song(song: &Song, settings: &LilypondSettings) -> Result<St
                     lyric_defs.push(LyricsDefinition {
                         var_name,
                         stanza: Some(format!("R{}.", refrain_number)),
-                        content: indent_lines(&content.content, "  "),
+                        content: lyrics_block(&content.content),
                     });
                     refrain_number += 1;
                 }
@@ -933,7 +992,7 @@ pub fn lilypond_sequential_from_song(
                 lyrics_defs.push(LyricsDefinition {
                     var_name,
                     stanza: Some(format!("{}.", verse_number)),
-                    content: indent_lines(&content.content, "  "),
+                    content: lyrics_block(&content.content),
                 });
                 verse_number += 1;
             }
@@ -951,7 +1010,7 @@ pub fn lilypond_sequential_from_song(
                 lyrics_defs.push(LyricsDefinition {
                     var_name,
                     stanza: None,
-                    content: indent_lines(&content.content, "  "),
+                    content: lyrics_block(&content.content),
                 });
             }
         }
@@ -1125,7 +1184,7 @@ pub fn lilypond_parts_from_song(
             voice_content: voice_content.to_string(),
             voice_ref: format!("\\{}", voice_var),
             lyrics_var_name: lyrics_var.to_string(),
-            lyrics_content: indent_lines(lyrics_content, "  "),
+            lyrics_content: lyrics_block(lyrics_content),
             lyrics_ref: format!("\\{}", lyrics_var),
             stanza,
             staff_size: settings.staff_size,
@@ -2426,5 +2485,82 @@ parts:
         let result = lilypond_from_song(&song, &LilypondSettings::default());
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("neither voice nor lyrics"));
+    }
+
+    // --- The `[…]` ignoreMelismata shorthand ----------------------------
+
+    /// LilyPond has no bracket form, so it is translated into the commands it
+    /// does understand. Left alone, the brackets are engraved as text.
+    #[test]
+    fn test_brackets_become_lilypond_commands() {
+        assert_eq!(
+            expand_ignore_melismata_brackets("[al le vier] hier"),
+            "\\set ignoreMelismata = ##t al le vier \\unset ignoreMelismata hier"
+        );
+    }
+
+    #[test]
+    fn test_brackets_around_a_single_word() {
+        assert_eq!(
+            expand_ignore_melismata_brackets("one [two] three"),
+            "one \\set ignoreMelismata = ##t two \\unset ignoreMelismata three"
+        );
+    }
+
+    /// A region may run over the line break of a lyrics block.
+    #[test]
+    fn test_brackets_spanning_lines_are_translated_once() {
+        assert_eq!(
+            expand_ignore_melismata_brackets("[one\ntwo] three"),
+            "\\set ignoreMelismata = ##t one\ntwo \\unset ignoreMelismata three"
+        );
+    }
+
+    /// An unclosed bracket must not emit a dangling `\unset`, and a stray
+    /// closing one must not emit an `\unset` that was never opened.
+    #[test]
+    fn test_unbalanced_brackets_do_not_emit_stray_commands() {
+        assert_eq!(
+            expand_ignore_melismata_brackets("[one two"),
+            "\\set ignoreMelismata = ##t one two"
+        );
+        assert_eq!(expand_ignore_melismata_brackets("one] two"), "one two");
+    }
+
+    /// Lyrics without a bracket have to come back byte for byte — every song
+    /// that never uses the feature must keep its current output.
+    #[test]
+    fn test_text_without_brackets_is_untouched() {
+        let text = "A -- ma -- zing grace\nHow sweet   the sound\n";
+        assert_eq!(expand_ignore_melismata_brackets(text), text);
+    }
+
+    /// The translation reaches the actual export, not just the helper.
+    #[test]
+    fn test_export_translates_the_bracket_shorthand() {
+        let yml = r#"
+version: 0.1
+title: Brackets
+score:
+  key: c major
+  time: 4/4
+parts:
+  - type: stanza
+    contents:
+    - type: voice
+      number: 1
+      content: |
+        c4( d ) e f
+    - type: lyrics
+      number: 1
+      content: |
+        [one two] three
+"#;
+        let song = song_yml::import_from_yml_string(yml).unwrap();
+        let ly = lilypond_from_song(&song, &LilypondSettings::default()).unwrap();
+
+        assert!(ly.contains("\\set ignoreMelismata = ##t"), "{}", ly);
+        assert!(ly.contains("\\unset ignoreMelismata"), "{}", ly);
+        assert!(!ly.contains('['), "a bracket survived into the score:\n{}", ly);
     }
 }

--- a/src/exporter/lilypond.rs
+++ b/src/exporter/lilypond.rs
@@ -543,8 +543,68 @@ global = {
 /// \addlyrics { \chorusSkip \verseTwo }
 /// ```
 ///
-/// Returns an error if the song has no voice content to export.
+/// Typeset a song that carries no notation as text.
+///
+/// There is no music to engrave, so the lyrics become a `\markup` block: one
+/// `\column` per verse, headed by its label, with a blank line between them.
+/// The result is a complete, compilable `.ly` file just like the score export.
+fn lilypond_lyrics_only(song: &Song, settings: &LilypondSettings) -> String {
+    let mut output = String::from("\\version \"2.24.0\"\n\n\\header {\n");
+    output.push_str(&format!(
+        "  title = \"{}\"\n",
+        escape_lilypond_string(&song.title)
+    ));
+    if let Some(author) = song.tag("author") {
+        output.push_str(&format!(
+            "  composer = \"{}\"\n",
+            escape_lilypond_string(author)
+        ));
+    }
+    output.push_str("  tagline = ##f\n}\n\n");
+
+    output.push_str(&format!(
+        "\\paper {{\n  #(set-paper-size \"{}\")\n}}\n\n",
+        settings.paper_size
+    ));
+
+    output.push_str("\\markup \\column {\n");
+    for (index, block) in crate::exporter::readable_lyrics_blocks(song)
+        .iter()
+        .enumerate()
+    {
+        if index > 0 {
+            output.push_str("  \\vspace #1\n");
+        }
+        output.push_str(&format!(
+            "  \\line {{ \\bold \"{}\" }}\n",
+            escape_lilypond_string(&block.label)
+        ));
+        for line in &block.lines {
+            output.push_str(&format!(
+                "  \\line {{ \"{}\" }}\n",
+                escape_lilypond_string(line)
+            ));
+        }
+    }
+    output.push_str("}\n");
+
+    output
+}
+
+/// A song without any notation is typeset as text through `\markup` — see
+/// `lilypond_lyrics_only`.
+///
+/// Returns an error only if the song has neither notation nor lyrics.
 pub fn lilypond_from_song(song: &Song, settings: &LilypondSettings) -> Result<String, String> {
+    if !song.has_voice_content() {
+        if !song.has_lyrics_content() {
+            return Err(
+                "Song has neither voice nor lyrics content for LilyPond export".to_string(),
+            );
+        }
+        return Ok(lilypond_lyrics_only(song, settings));
+    }
+
     let parts = song.parts();
 
     // --- Step 1: Find the stanza (verse) voice ---
@@ -2315,5 +2375,56 @@ parts:
         for part in &rendered {
             assert!(!part.svg.is_empty(), "SVG for {} should not be empty", part.label);
         }
+    }
+
+    // --- Lyrics-only songs ----------------------------------------------
+
+    /// Build a song whose only content is one verse of lyrics.
+    fn lyrics_only_song(title: &str, lyrics: &str) -> Song {
+        let mut song = Song::new(title);
+        let id = song.add_part_of_type(SongPartType::Verse, Some(1));
+        let part = song.part_mut(&id).unwrap();
+        part.add_content(SongPartContent {
+            content_type: SongPartContentType::Lyrics {
+                language: crate::song::LyricLanguage::Default,
+            },
+            content: lyrics.to_string(),
+        });
+        song
+    }
+
+    /// Nothing to engrave, but the text is still worth typesetting: the lyrics
+    /// become a `\markup` block instead of a staff.
+    #[test]
+    fn test_song_without_voice_is_typeset_as_markup() {
+        let song = lyrics_only_song("No Voice", "First line\nSecond line");
+        let ly = lilypond_from_song(&song, &LilypondSettings::default()).unwrap();
+
+        assert!(ly.contains("\\version \"2.24.0\""), "{}", ly);
+        assert!(ly.contains("title = \"No Voice\""), "{}", ly);
+        assert!(ly.contains("\\markup \\column {"), "{}", ly);
+        assert!(ly.contains("\\line { \"First line\" }"), "{}", ly);
+        assert!(ly.contains("\\line { \"Second line\" }"), "{}", ly);
+        // There is no music, so no staff is set up.
+        assert!(!ly.contains("\\score"), "{}", ly);
+    }
+
+    /// Quotes and backslashes in the text must not break out of the literal.
+    #[test]
+    fn test_markup_escapes_quotes_in_the_lyrics() {
+        let song = lyrics_only_song("Quoting", "He said \"go\"");
+        let ly = lilypond_from_song(&song, &LilypondSettings::default()).unwrap();
+
+        assert!(ly.contains(r#"\line { "He said \"go\"" }"#), "{}", ly);
+    }
+
+    #[test]
+    fn test_song_without_voice_and_lyrics_is_an_error() {
+        let mut song = Song::new("Empty");
+        song.add_part_of_type(SongPartType::Verse, Some(1));
+
+        let result = lilypond_from_song(&song, &LilypondSettings::default());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("neither voice nor lyrics"));
     }
 }

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -7,3 +7,64 @@ pub mod lilypond;
 pub mod abc;
 
 pub mod text;
+
+use crate::song::{Song, SongPartType};
+
+/// One block of readable lyrics: a label such as `"1."` or `"Refrain"` and the
+/// lines of text below it.
+pub(crate) struct LyricsBlock {
+    pub label: String,
+    pub lines: Vec<String>,
+}
+
+/// The lyrics of a song as readable text, one block per part that has any.
+///
+/// The notation exporters fall back to this when a song carries no music:
+/// there is nothing to engrave, but the text is still worth typesetting. The
+/// LilyPond syllable markup (`--`, `_`, `\set …`) is stripped, so the result
+/// reads the way an audience would see it rather than the way it is sung.
+pub(crate) fn readable_lyrics_blocks(song: &Song) -> Vec<LyricsBlock> {
+    let mut blocks = Vec::new();
+    let mut verse_number = 1u32;
+
+    for part in song.parts() {
+        for content in &part.contents {
+            if !content.content_type.is_lyrics() {
+                continue;
+            }
+
+            let lines: Vec<String> = slides::lyrics_for_reading(&content.content)
+                .lines()
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .collect();
+
+            if lines.is_empty() {
+                continue;
+            }
+
+            // Verses are numbered through; everything else is named after its
+            // part type, which is what a reader needs to follow the order.
+            let label = match part.part_type {
+                SongPartType::Verse => {
+                    let label = format!("{}.", verse_number);
+                    verse_number += 1;
+                    label
+                }
+                SongPartType::Refrain | SongPartType::Chorus => "Refrain".to_string(),
+                other => {
+                    let name = other.as_str();
+                    let mut chars = name.chars();
+                    match chars.next() {
+                        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                        None => name.to_string(),
+                    }
+                }
+            };
+
+            blocks.push(LyricsBlock { label, lines });
+        }
+    }
+
+    blocks
+}

--- a/src/exporter/slides.rs
+++ b/src/exporter/slides.rs
@@ -21,10 +21,11 @@ pub fn lyrics_for_reading(text: &str) -> String {
 
 /// Strip LilyPond lyric markup from lyrics text for presentation display.
 ///
-/// Removes syllable separators (`--`), melisma placeholders (`_`) and inline
-/// commands together with their arguments (e.g.
-/// `\set ignoreMelismata = ##t`, `\unset ignoreMelismata`), none of which are
-/// meant to be seen by the audience.
+/// Removes syllable separators (`--`), melisma placeholders (`_`), the `[…]`
+/// brackets that mark a region where melismata are ignored, and inline commands
+/// together with their arguments (e.g. `\set ignoreMelismata = ##t`,
+/// `\unset ignoreMelismata`) — none of which are meant to be seen by the
+/// audience.
 fn strip_lilypond_markers(text: &str) -> String {
     // Replace " -- " (syllable separator) with nothing, joining syllables
     let result = text.replace(" -- ", "");
@@ -56,6 +57,12 @@ fn strip_lilypond_markers_in_line(line: &str) -> String {
         }
         // `_` is LilyPond's melisma extender and carries no text.
         if word == "_" {
+            continue;
+        }
+        // `[…]` marks a region where melismata are ignored. The brackets are
+        // markup, not lyrics, and may hug the words they enclose.
+        let word = word.trim_start_matches('[').trim_end_matches(']');
+        if word.is_empty() {
             continue;
         }
         kept.push(word);
@@ -911,5 +918,29 @@ mod tests {
         let input = "A -- ma -- zing grace, How sweet the sound";
         let result = strip_lilypond_markers(input);
         assert_eq!(result, "Amazing grace, How sweet the sound");
+    }
+
+    /// The `[…]` region markers are markup for the engraver, not words. An
+    /// audience must never see them on a slide.
+    #[test]
+    fn test_ignore_melismata_brackets_are_stripped() {
+        assert_eq!(
+            strip_lilypond_markers("[al le vier] hier"),
+            "al le vier hier"
+        );
+        assert_eq!(strip_lilypond_markers("one [two] three"), "one two three");
+        // Brackets standing on their own leave no empty word behind.
+        assert_eq!(strip_lilypond_markers("[ one ]"), "one");
+    }
+
+    /// The command form is dropped with its arguments, as before.
+    #[test]
+    fn test_ignore_melismata_commands_are_stripped() {
+        assert_eq!(
+            strip_lilypond_markers(
+                "\\set ignoreMelismata = ##t one two \\unset ignoreMelismata three"
+            ),
+            "one two three"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use cantara_songlib::templating::MetaTemplate;
 use cantara_songlib::slides_from_file;
 
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -22,8 +22,8 @@ struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// The song file(s) to read. The `text` and `presentation` commands accept
-    /// several; the music formats take exactly one.
+    /// The song file(s) to read. The `text`, `presentation` and `abc` commands
+    /// accept several; `lilypond` takes exactly one.
     #[arg(global = true)]
     files: Vec<PathBuf>,
 }
@@ -163,6 +163,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(files)
     }
 
+    /// Warn about a song that carries neither notation nor lyrics.
+    ///
+    /// Such a file is empty, not broken — an export run over a whole song
+    /// folder should say so and carry on rather than abort on the first one.
+    /// Returns whether the song was empty.
+    fn warn_if_empty(song: &cantara_songlib::song::Song, file: &Path) -> bool {
+        let empty = !song.has_voice_content() && !song.has_lyrics_content();
+        if empty {
+            eprintln!(
+                "warning: '{}' has neither notation nor lyrics — nothing to export",
+                file.display()
+            );
+        }
+        empty
+    }
+
+    /// Set the `X:` reference number of an ABC tune.
+    ///
+    /// Tunes in one ABC file have to be numbered apart; the exporter always
+    /// emits `X:1` because it only ever sees a single song.
+    fn renumber_tune(abc: &str, number: usize) -> String {
+        match abc.split_once('\n') {
+            Some((first, rest)) if first.starts_with("X:") => {
+                format!("X:{}\n{}", number, rest)
+            }
+            _ => abc.to_string(),
+        }
+    }
+
     /// The single input file, for the commands that take exactly one.
     fn only(files: &[PathBuf]) -> Result<&PathBuf, Box<dyn std::error::Error>> {
         match files {
@@ -253,12 +282,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             paper_size,
             indent,
         } => {
-            let song = import_song_from_file(only(inputs(&cli.files)?)?)?;
+            let file = only(inputs(&cli.files)?)?;
+            let song = import_song_from_file(file)?;
             let settings = LilypondSettings {
                 paper_size: paper_size.clone(),
                 layout_indent: indent.clone(),
                 ..LilypondSettings::default()
             };
+            // A song with neither notation nor lyrics is nothing to engrave,
+            // but it is not a broken input either.
+            if warn_if_empty(&song, file) {
+                return Ok(());
+            }
             match exporter::lilypond::lilypond_from_song(&song, &settings) {
                 Ok(ly_output) => println!("{}", ly_output),
                 Err(e) => return Err(e.into()),
@@ -270,15 +305,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             include_chords,
             all_verses,
         } => {
-            let song = import_song_from_file(only(inputs(&cli.files)?)?)?;
+            let files = inputs(&cli.files)?;
             let settings = AbcSettings {
                 unit_note_length: unit_note_length.clone(),
                 include_chords: *include_chords,
                 include_all_verses: *all_verses,
             };
-            match exporter::abc::abc_from_song(&song, &settings) {
-                Ok(abc_output) => println!("{}", abc_output),
-                Err(e) => return Err(e.into()),
+
+            // An ABC file holds a sequence of tunes, so several songs simply
+            // follow one another — each with its own X: number.
+            let mut tune_number = 0usize;
+            for file in files {
+                let song = import_song_from_file(file)?;
+                if warn_if_empty(&song, file) {
+                    continue;
+                }
+                let abc_output = exporter::abc::abc_from_song(&song, &settings)?;
+                tune_number += 1;
+                // The trailing newline of `println!` doubles as the blank line
+                // the ABC standard wants between two tunes.
+                println!("{}", renumber_tune(&abc_output, tune_number));
             }
         }
     }

--- a/src/song.rs
+++ b/src/song.rs
@@ -673,6 +673,21 @@ impl Song {
         &self.parts
     }
 
+    /// Whether any part carries notation, following repetition references.
+    ///
+    /// The notation exporters use this to tell a song they can engrave from a
+    /// lyrics-only one, which they typeset as plain text instead.
+    pub fn has_voice_content(&self) -> bool {
+        self.parts
+            .iter()
+            .any(|part| self.voice_for_part(part).is_some())
+    }
+
+    /// Whether any part carries lyrics.
+    pub fn has_lyrics_content(&self) -> bool {
+        self.parts.iter().any(|part| part.has_lyrics())
+    }
+
     /// Mutable access to every part.
     pub fn parts_mut(&mut self) -> &mut [SongPart] {
         &mut self.parts

--- a/tests/abc_comprehensive_validation.rs
+++ b/tests/abc_comprehensive_validation.rs
@@ -228,6 +228,12 @@ fn count_syllables(line: &str) -> usize {
     let body = line.trim_start_matches("w:");
     let mut count = 0usize;
     for word in body.split_whitespace() {
+        // A melisma marker holds the previous syllable over a further note. It
+        // is not sung on its own, and the note it covers is not counted as
+        // singable either, so it must stay out of this count.
+        if word == "_" {
+            continue;
+        }
         // Unescaped hyphens split a word into further syllables.
         let mut chars = word.chars().peekable();
         let mut current = String::new();
@@ -476,7 +482,8 @@ fn test_refrain_is_exported() {
         abc
     );
     assert!(
-        abc.contains("Denn wer sich rüh-men will,"),
+        // "Denn" is held across the slurred `fis8( g )`.
+        abc.contains("Denn _ wer sich rüh-men will,"),
         "the refrain lyrics are missing:\n{}",
         abc
     );

--- a/tests/abc_comprehensive_validation.rs
+++ b/tests/abc_comprehensive_validation.rs
@@ -387,6 +387,12 @@ fn test_bars_match_the_meter() {
 
 /// Each `w:` line has to carry exactly as many syllables as its music line has
 /// singable notes, otherwise the text drifts away from the melody.
+///
+/// `singable` counts slurs and ties as melismata, which is what the music says
+/// on its own. A verse that switches melismata off — `\set ignoreMelismata` or
+/// the `[…]` shorthand — legitimately carries *more* syllables than that, so a
+/// fixture using the feature would trip this check. Model the ignore regions
+/// here before adding one, rather than loosening the bound.
 #[test]
 fn test_lyrics_align_with_notes() {
     for path in TEST_FILES {

--- a/tests/ccli_import.rs
+++ b/tests/ccli_import.rs
@@ -61,20 +61,37 @@ fn test_trailer_metadata_reaches_the_slides() {
     );
 }
 
-/// A CCLI export carries lyrics but no music, so the sheet-music exporters have
-/// to refuse it with a clear message instead of panicking or emitting an empty
-/// score.
+/// A CCLI export carries lyrics but no music. There is no melody to engrave,
+/// so both sheet-music exporters fall back to typesetting the text instead of
+/// refusing the song.
 #[test]
-fn test_sheet_music_export_reports_the_missing_melody() {
+fn test_sheet_music_export_typesets_the_lyrics_without_a_melody() {
     let song = import_song_from_file(GENERIC).expect("import");
+    assert!(!song.has_voice_content(), "the fixture has no melody");
 
-    let lilypond = lilypond_from_song(&song, &LilypondSettings::default());
-    assert!(lilypond.is_err());
-    assert!(lilypond.unwrap_err().contains("no voice content"));
+    let lilypond = lilypond_from_song(&song, &LilypondSettings::default()).expect("markup export");
+    assert!(
+        lilypond.contains("\\markup \\column {"),
+        "the lyrics are not typeset as markup:\n{}",
+        lilypond
+    );
+    assert!(
+        !lilypond.contains("\\score"),
+        "there is no melody, so there must be no staff:\n{}",
+        lilypond
+    );
 
-    let abc = abc_from_song(&song, &AbcSettings::default());
-    assert!(abc.is_err());
-    assert!(abc.unwrap_err().contains("no voice content"));
+    let abc = abc_from_song(&song, &AbcSettings::default()).expect("words export");
+    assert!(
+        abc.contains("W:"),
+        "the lyrics are not carried as W: fields:\n{}",
+        abc
+    );
+    assert!(
+        !abc.contains("\nw:"),
+        "there are no notes to align syllables to:\n{}",
+        abc
+    );
 }
 
 /// The singing order is derived from the section headings, so a pre-chorus ends


### PR DESCRIPTION
Add feature to ignore melismatas and export markup test to Lilypond and ABC notation. Update version accordingly.