### PR TITLE
Features/meta on all slides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.5"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -108,9 +108,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.6"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.6"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.4.4"
+version = "6.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c54236f9045c8004a77942bebc52145b4844639db934a5c70fe08617fbe61a"
+checksum = "4633d16a2350341713c379d6d06a4b9e1845329386026a49ce4fd09c2f3b16f6"
 dependencies = [
  "derive_builder",
  "log",
@@ -339,9 +339,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-modular"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8e500409e6cd603b03e477c26a6caecdc27ac58979a53e881c75eafc079f44"
+checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
 
 [[package]]
 name = "num-order"
@@ -366,9 +366,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pest"
-version = "2.9.0"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.9.0"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.9.0"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.9.0"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.18"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -514,6 +514,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -586,18 +587,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.20"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.20"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -108,9 +108,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.4.3"
+version = "6.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4633d16a2350341713c379d6d06a4b9e1845329386026a49ce4fd09c2f3b16f6"
+checksum = "75c54236f9045c8004a77942bebc52145b4844639db934a5c70fe08617fbe61a"
 dependencies = [
  "derive_builder",
  "log",
@@ -327,9 +327,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
@@ -339,9 +339,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-modular"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+checksum = "bd8e500409e6cd603b03e477c26a6caecdc27ac58979a53e881c75eafc079f44"
 
 [[package]]
 name = "num-order"
@@ -366,9 +366,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -514,7 +514,6 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -587,18 +586,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "cantara-songlib"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cbindgen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Jan Martin Reckel jm.reckel@t-online.de"]
 description = "Functionalities to import, manage and export songs in various formats"
 keywords = ["music", "sheets", "presentation"]
 license = "AGPL-3.0"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 repository = "https://github.com/CantaraProject/cantara-songlib"
 

--- a/docs/meta-information.md
+++ b/docs/meta-information.md
@@ -104,20 +104,22 @@ let show = ShowMetaInformation {
     title_slide: true,
     first_slide: false,
     last_slide: true,
+    all_slides: false,
 };
 assert!(show.on_title_slide());
 ```
 
-| Constructor | Title slide | First content slide | Last content slide |
-|-------------|:-----------:|:-------------------:|:------------------:|
-| `none()` | | | |
-| `title_slide()` | ● | | |
-| `first_slide()` | | ● | |
-| `last_slide()` | | | ● |
-| `first_and_last_slide()` | | ● | ● |
-| `all()` | ● | ● | ● |
+| Constructor | Title slide | First content slide | Last content slide | Other slides |
+|-------------|:-----------:|:-------------------:|:------------------:|:------------:|
+| `none()` | | | |              |
+| `title_slide()` | ● | | |              |
+| `first_slide()` | | ● | |              |
+| `last_slide()` | | | ● |              |
+| `first_and_last_slide()` | | ● | ● |              |
+| `title_first_slide_last_slide()` | ● | ● | ● |              |
+| `all_slides()` | ● | ● | ● |        ●        |
 
-Two details worth knowing:
+Two details are worth knowing:
 
 * The **title slide is its own position**. Asking for the metadata on the
   content slides leaves the title slide clean, and the other way round.

--- a/src/exporter/slides.rs
+++ b/src/exporter/slides.rs
@@ -794,7 +794,7 @@ mod tests {
             (ShowMetaInformation::first_slide(), vec![1]),
             (ShowMetaInformation::last_slide(), vec![3]),
             (ShowMetaInformation::first_and_last_slide(), vec![1, 3]),
-            (ShowMetaInformation::all(), vec![0, 1, 3]),
+            (ShowMetaInformation::title_first_slide_last_slide(), vec![0, 1, 3]),
         ];
 
         for (show, expected) in cases {
@@ -850,7 +850,7 @@ mod tests {
         let song = song_with_metadata();
         let settings = SlideSettings {
             meta_syntax: String::new(),
-            ..settings_with(ShowMetaInformation::all())
+            ..settings_with(ShowMetaInformation::title_first_slide_last_slide())
         };
         assert!(slides_with_meta(&song, &settings).is_empty());
     }
@@ -864,7 +864,7 @@ mod tests {
 
         let settings = SlideSettings {
             meta_syntax: "{{author}}".to_string(),
-            ..settings_with(ShowMetaInformation::all())
+            ..settings_with(ShowMetaInformation::title_first_slide_last_slide())
         };
         assert!(slides_with_meta(&song, &settings).is_empty());
     }
@@ -877,7 +877,7 @@ mod tests {
         let song = song_with_metadata();
         let settings = SlideSettings {
             meta_syntax: "{{#if author}}never closed".to_string(),
-            ..settings_with(ShowMetaInformation::all())
+            ..settings_with(ShowMetaInformation::title_first_slide_last_slide())
         };
 
         let slides = slides_from_song(&song, &settings);
@@ -906,7 +906,7 @@ mod tests {
 
         let settings = SlideSettings {
             language: LanguageConfiguration::MultiLanguage(vec![]),
-            ..settings_with(ShowMetaInformation::all())
+            ..settings_with(ShowMetaInformation::title_first_slide_last_slide())
         };
 
         // slides: 0 = title, 1 = verse one, 2 = verse two.

--- a/src/importer/classic_song.rs
+++ b/src/importer/classic_song.rs
@@ -891,7 +891,7 @@ Refrain B.";
         let presentation_settings = SlideSettings {
             title_slide: true,
             meta_syntax: "{{title}} ({{author}})".to_string(),
-            show_meta_information: ShowMetaInformation::all(),
+            show_meta_information: ShowMetaInformation::title_first_slide_last_slide(),
             empty_last_slide: true,
             show_spoiler: true ,
             max_lines: Some(10),

--- a/src/slides.rs
+++ b/src/slides.rs
@@ -719,14 +719,14 @@ impl ShowMetaInformation {
     /// assert_eq!(ShowMetaInformation::from_bits(3), ShowMetaInformation::first_and_last_slide());
     /// assert_eq!(ShowMetaInformation::from_bits(4), ShowMetaInformation::title_slide());
     /// assert_eq!(ShowMetaInformation::from_bits(7), ShowMetaInformation::title_first_slide_last_slide());
-    /// assert_eq!(ShowMetaInformation::from_bits(8), ShowMetaInformation::all_slides());
+    /// assert_eq!(ShowMetaInformation::from_bits(15), ShowMetaInformation::all_slides());
     /// ```
     pub fn from_bits(bits: u8) -> Self {
         ShowMetaInformation {
             first_slide: bits & 0b001 != 0,
             last_slide: bits & 0b010 != 0,
             title_slide: bits & 0b100 != 0,
-            all_slides: bits & 0b111 != 0,
+            all_slides: bits & 0b1000 != 0,
         }
     }
 

--- a/src/slides.rs
+++ b/src/slides.rs
@@ -679,10 +679,10 @@ impl ShowMetaInformation {
         self.last_slide || self.all_slides
     }
 
-    /// Whether the content slide at `index` out of `count` shows it.
+    /// Function to decide whether the content slide at `index` out of `count` should render meta-information
+    /// according to the settings in `self`.
     ///
-    /// A song with a single content slide has that slide be both the first and
-    /// the last, so it shows the metadata if either position is selected.
+    /// This function should be called when generating slides to decide whether to put meta-information on it.
     ///
     /// ```
     /// use cantara_songlib::slides::ShowMetaInformation;
@@ -693,6 +693,12 @@ impl ShowMetaInformation {
     ///
     /// // The only slide of a song counts as the last one.
     /// assert!(last_only.on_content_slide(0, 1));
+    ///
+    /// // When `all_slides` is set to `true`, every slide should contain meta-information.
+    /// let all_slides = ShowMetaInformation::all_slides();
+    /// assert!(all_slides.on_content_slide(0, 3));
+    /// assert!(all_slides.on_content_slide(1, 3));
+    /// assert!(all_slides.on_content_slide(2, 3));
     /// ```
     pub fn on_content_slide(&self, index: usize, count: usize) -> bool {
         if count == 0 {

--- a/src/slides.rs
+++ b/src/slides.rs
@@ -557,7 +557,7 @@ impl Default for SlideSettings {
         SlideSettings {
             title_slide: true,
             meta_syntax: "".to_string(),
-            show_meta_information: ShowMetaInformation::all(),
+            show_meta_information: ShowMetaInformation::title_first_slide_last_slide(),
             empty_last_slide: true,
             show_spoiler: true,
             max_lines: None,
@@ -584,6 +584,7 @@ impl Default for SlideSettings {
 ///     title_slide: true,
 ///     first_slide: false,
 ///     last_slide: true,
+///     all_slides: true,
 /// };
 /// assert!(custom.on_title_slide());
 /// ```
@@ -595,6 +596,8 @@ pub struct ShowMetaInformation {
     pub first_slide: bool,
     /// Show it on the last content slide.
     pub last_slide: bool,
+    /// Show meta information on all slides
+    pub all_slides: bool,
 }
 
 impl ShowMetaInformation {
@@ -633,12 +636,23 @@ impl ShowMetaInformation {
             title_slide: false,
             first_slide: true,
             last_slide: true,
+            all_slides: false,
         }
     }
 
     /// Show it on the title slide and on the first and last content slide.
-    pub fn all() -> Self {
+    pub fn title_first_slide_last_slide() -> Self {
         ShowMetaInformation {
+            title_slide: true,
+            first_slide: true,
+            last_slide: true,
+            all_slides: false,
+        }
+    }
+
+    pub fn all_slides() -> Self {
+        ShowMetaInformation {
+            all_slides: true,
             title_slide: true,
             first_slide: true,
             last_slide: true,
@@ -647,22 +661,22 @@ impl ShowMetaInformation {
 
     /// Whether anything is shown at all.
     pub fn is_none(&self) -> bool {
-        !self.title_slide && !self.first_slide && !self.last_slide
+        !self.title_slide && !self.first_slide && !self.last_slide && !self.all_slides
     }
 
     /// Whether the title slide shows the meta information.
     pub fn on_title_slide(&self) -> bool {
-        self.title_slide
+        self.title_slide || self.all_slides
     }
 
     /// Whether the first content slide shows the meta information.
     pub fn on_first_slide(&self) -> bool {
-        self.first_slide
+        self.first_slide || self.all_slides
     }
 
     /// Whether the last content slide shows the meta information.
     pub fn on_last_slide(&self) -> bool {
-        self.last_slide
+        self.last_slide || self.all_slides
     }
 
     /// Whether the content slide at `index` out of `count` shows it.
@@ -684,6 +698,9 @@ impl ShowMetaInformation {
         if count == 0 {
             return false;
         }
+        if self.all_slides {
+            return true;
+        }
         (self.first_slide && index == 0) || (self.last_slide && index + 1 == count)
     }
 
@@ -701,13 +718,15 @@ impl ShowMetaInformation {
     /// assert_eq!(ShowMetaInformation::from_bits(2), ShowMetaInformation::last_slide());
     /// assert_eq!(ShowMetaInformation::from_bits(3), ShowMetaInformation::first_and_last_slide());
     /// assert_eq!(ShowMetaInformation::from_bits(4), ShowMetaInformation::title_slide());
-    /// assert_eq!(ShowMetaInformation::from_bits(7), ShowMetaInformation::all());
+    /// assert_eq!(ShowMetaInformation::from_bits(7), ShowMetaInformation::title_first_slide_last_slide());
+    /// assert_eq!(ShowMetaInformation::from_bits(8), ShowMetaInformation::all_slides());
     /// ```
     pub fn from_bits(bits: u8) -> Self {
         ShowMetaInformation {
             first_slide: bits & 0b001 != 0,
             last_slide: bits & 0b010 != 0,
             title_slide: bits & 0b100 != 0,
+            all_slides: bits & 0b111 != 0,
         }
     }
 

--- a/tests/complex_slides.rs
+++ b/tests/complex_slides.rs
@@ -718,7 +718,7 @@ fn test_meta_information_follows_the_usual_settings() {
         (ShowMetaInformation::title_slide(), vec![0]),
         (ShowMetaInformation::first_slide(), vec![1]),
         (ShowMetaInformation::last_slide(), vec![2]),
-        (ShowMetaInformation::all(), vec![0, 1, 2]),
+        (ShowMetaInformation::title_first_slide_last_slide(), vec![0, 1, 2]),
     ];
 
     for (show, expected) in cases {


### PR DESCRIPTION
This pull request implements the option to include meta information on **all** slides. Therefore, a new struct field in `ShowMetaInformation` named `all_slides` (bool) has been added.
The depending functions and doc tests as well as the documentation has been updated accordingly.

As this PR would be a breaking change, the version number has been updated to v0.4.0. Cargo update has been run accordingly.